### PR TITLE
CHROMIUM: base/cpu: guard cpu_uevent with ARCH_HAS_CPU_AUTOPROBE

### DIFF
--- a/drivers/base/cpu.c
+++ b/drivers/base/cpu.c
@@ -314,6 +314,7 @@ static ssize_t print_cpu_modalias(struct device *dev,
 #define print_cpu_modalias	arch_print_cpu_modalias
 #endif
 
+#ifdef CONFIG_ARCH_HAS_CPU_AUTOPROBE
 static int cpu_uevent(struct device *dev, struct kobj_uevent_env *env)
 {
 	char *buf = kzalloc(PAGE_SIZE, GFP_KERNEL);
@@ -324,6 +325,7 @@ static int cpu_uevent(struct device *dev, struct kobj_uevent_env *env)
 	}
 	return 0;
 }
+#endif
 #endif
 
 /*


### PR DESCRIPTION
Commit [0], inherited from the android 3.18 tree, makes setting:
  cpu->dev.bus->uevent = cpu_uevent
conditional on CONFIG_ARCH_HAS_CPU_AUTOPROBE.
Since that is the only reference to cpu_uevent, the function definition
itself must also be guarded to avoid the following compiler warning:

drivers/base/cpu.c:314:12: warning: 'cpu_uevent' defined but not used [-Wunused-function]
 static int cpu_uevent(struct device *dev, struct kobj_uevent_env *env)
            ^
[0] commit 9025d688a3bcd3c21d4b5dca9a8cd4b8b924f06b
    cpu: add generic support for CPU feature based module autoloading

This patch was sent to LKML for review [1], but AFAICT the version in
android-3.18, at least, was never accepted.
[1] https://lkml.org/lkml/2014/1/29/277

Signed-off-by: Daniel Kurtz <djkurtz@chromium.org>

BUG=chromium:512697
TEST=emerge-oak chromeos-kernel-3_18
  => No [-Wunused-function] warning in drivers/base/cpu.c

Change-Id: I15a4f96a8cfee7995481b3377142997363691816
Reviewed-on: https://chromium-review.googlesource.com/287426
Reviewed-by: Nicolas Boichat <drinkcat@chromium.org>
Trybot-Ready: Nicolas Boichat <drinkcat@chromium.org>
Commit-Queue: Daniel Kurtz <djkurtz@chromium.org>
Trybot-Ready: Daniel Kurtz <djkurtz@chromium.org>
Tested-by: Daniel Kurtz <djkurtz@chromium.org>